### PR TITLE
1.2.0 beta verified, ready for production release

### DIFF
--- a/ios/FreestarNativeAdViewManager.m
+++ b/ios/FreestarNativeAdViewManager.m
@@ -24,7 +24,6 @@ static NSString* NATIVE_EVENT_AD_CLICKED = @"onNativeAdClicked";
 @implementation FreestarNativeAd (ReactBridge)
 
 -(void)setRequestOptions:(NSDictionary *)options {
-    NSLog(@"xxx 3");
     NSDictionary *targetingParams = options[@"targetingParams"];
     if(targetingParams && targetingParams.count > 0) {
         [targetingParams enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString* obj, BOOL * _Nonnull stop) {
@@ -58,7 +57,6 @@ static NSString* NATIVE_EVENT_AD_CLICKED = @"onNativeAdClicked";
 }
 
 - (UIView *)view {
-    NSLog(@"xxx 1");
     self.ad = [[FreestarNativeAd alloc] initWithDelegate:self andSize:[self adSize]];
     return self.ad;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@freestar/freestar-plugin-react-native",
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@freestar/freestar-plugin-react-native",
-  "version": "1.2.0-beta.2",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "Ads",
     "ReactNative"
   ],
-  "version": "1.2.0-beta.2",
+  "version": "1.2.0-beta.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/freestarcapital/freestar-plugin-react-native"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "Ads",
     "ReactNative"
   ],
-  "version": "1.2.0-beta.2",
+  "version": "1.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/freestarcapital/freestar-plugin-react-native"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "Ads",
     "ReactNative"
   ],
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0-beta.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/freestarcapital/freestar-plugin-react-native"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "MediumNativeAd2.js",
     "MediumNativeAd3.js",
     "MediumNativeAd4.js",
-    "freestar-plugin-react.podspec"
+    "freestar-plugin-react-native.podspec"
   ],
   "main": "FreestarReact.js",
   "name": "@freestar/freestar-plugin-react-native",
@@ -54,7 +54,7 @@
     "Ads",
     "ReactNative"
   ],
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0-beta.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/freestarcapital/freestar-plugin-react-native"


### PR DESCRIPTION
We can now release the npm package with updated MRECs, banners, and Native ad formats for iOS.

Completion of [ENG-6964](https://freestar.atlassian.net/browse/ENG-6964).

Once merged into master, should be published to npmjs.